### PR TITLE
Suppress type warning

### DIFF
--- a/src/vgps3/plugins/ign/ign.js
+++ b/src/vgps3/plugins/ign/ign.js
@@ -33,7 +33,7 @@ vgps3.ign.Map = function() {
  */
 vgps3.ign.Map.prototype.init = function(vgps) {
   var gMap = vgps.getGoogleMap();
-  gMap.mapTypes.set(vgps3.ign.MapTypeId.TERRAIN, this.getIgnMapType_());
+  gMap.mapTypes.set(vgps3.ign.MapTypeId.TERRAIN, /** @type {?} */ (this.getIgnMapType_()));
 };
 
 


### PR DESCRIPTION
The type warning is due to a bug in the Google Maps API v3 externs file.
It is safe to ignore it.
